### PR TITLE
Update normalize url version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gravatar": "^1.8.2",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.1.3",
-    "normalize-url": "^7.0.2",
+    "normalize-url": "6.1.0",
     "request": "^2.88.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Normalize-url module can't be imported using require in the latest versions